### PR TITLE
Center call to action div using flexbox

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -2,13 +2,17 @@ body {
   font-family: 'Comic Neue', cursive, sans-serif;
 }
 
+#overlay {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 #start {
-  margin: 2em;
   padding: 1em;
   color: white;
   background-color: black;
   width: 75%;
-  margin-left: 12.5%;
   cursor: pointer;
   text-align: center;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
   <link rel="icon" href="data:,">
 </head>
 <body>
-  <div id="overlay">
+  <div id="overlay" style="display: flex; justify-content: center; align-items: center;">
     <div id="start">
       <marquee direction="right" behavior="alternate" scrollamount="10">🔈 ⚠️ Click Me For Loud Noises ⚠️ 🔈</marquee>
     </div>


### PR DESCRIPTION
Related to #26

Center the "click for loud noises" div both horizontally and vertically using flexbox.

* Add `display: flex`, `justify-content: center`, and `align-items: center` to `#overlay` in `public/index.css`.
* Remove `margin-left` and `margin` from `#start` in `public/index.css`.
* Add inline styles `display: flex`, `justify-content: center`, and `align-items: center` to `#overlay` in `public/index.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MylesBorins/myles.dev/issues/26?shareId=72c70b7d-5162-4862-9841-657af1c039de).