### PR TITLE
Center 'click for loud noises' div

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -7,8 +7,6 @@ body {
   padding: 1em;
   color: white;
   background-color: black;
-  width: 75%;
-  margin-left: 12.5%;
   cursor: pointer;
   text-align: center;
 }
@@ -53,6 +51,12 @@ body {
 
 #github-link a img:hover {
   transform: scale(1.1);
+}
+
+#overlay {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 @media only screen and (min-width: 800px) {

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
   <link rel="icon" href="data:,">
 </head>
 <body>
-  <div id="overlay">
+  <div id="overlay" style="height: 100vh;">
     <div id="start">
       <marquee direction="right" behavior="alternate" scrollamount="10">🔈 ⚠️ Click Me For Loud Noises ⚠️ 🔈</marquee>
     </div>


### PR DESCRIPTION
Related to #26

Center the "click for loud noises" div both horizontally and vertically using flexbox.

* **public/index.css**
  - Remove `margin-left: 12.5%` and `width: 75%` from `#start`.
  - Add `display: flex`, `justify-content: center`, and `align-items: center` to `#overlay`.

* **public/index.html**
  - Add `style="height: 100vh;"` to `#overlay` div.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MylesBorins/myles.dev/issues/26?shareId=0152078b-9967-4f13-9061-f1276311c9f6).